### PR TITLE
Cope with API change in 1.21.1

### DIFF
--- a/Storj-Exporter-Boom-Table.json
+++ b/Storj-Exporter-Boom-Table.json
@@ -1184,14 +1184,14 @@
           "refId": "J"
         },
         {
-          "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"}) by(instance) * 100",
+          "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"}) by(instance) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "{{instance}} | Uptime",
           "refId": "C"
         },
         {
-          "expr": "avg(storj_sat_audit{type=\"score\", instance=~\"$node.*\"}) by(instance) * 100",
+          "expr": "avg(storj_sat_audit{type=~\"score|auditScore\", instance=~\"$node.*\"}) by(instance) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "{{instance}} | Audit",
@@ -2071,14 +2071,14 @@
           "refId": "E"
         },
         {
-          "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"}) by(url) * 100",
+          "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"}) by(url) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "{{url}} | Uptime",
           "refId": "C"
         },
         {
-          "expr": "avg(storj_sat_audit{type=\"score\",instance=~\"$node.*\"}) by(url) * 100",
+          "expr": "avg(storj_sat_audit{type=~\"score|auditScore\",instance=~\"$node.*\"}) by(url) * 100",
           "hide": false,
           "legendFormat": "{{url}} | Audit",
           "refId": "D"

--- a/alternatives/Storj-Exporter-Boom-Table-fmoledina.json
+++ b/alternatives/Storj-Exporter-Boom-Table-fmoledina.json
@@ -703,14 +703,14 @@
           "refId": "B"
         },
         {
-          "expr": "avg(storj_sat_summary{type=\"onlineScore\",satellite=~\"^$satellite\"}) by(instance) * 100",
+          "expr": "avg(storj_sat_summary{type=\"onlineScore\",satellite=~\"^$satellite\"} or storj_sat_audit{type=\"onlineScore\", satellite=~\"^$satellite\"}) by(instance) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "{{instance}} | Online",
           "refId": "C"
         },
         {
-          "expr": "avg(storj_sat_audit{type=\"score\",satellite=~\"^$satellite\"}) by(instance) * 100",
+          "expr": "avg(storj_sat_audit{type=~\"score|auditScore\",satellite=~\"^$satellite\"}) by(instance) * 100",
           "hide": false,
           "interval": "",
           "legendFormat": "{{instance}} | Audit",
@@ -1965,7 +1965,7 @@
       "repeatDirection": "v",
       "targets": [
         {
-          "expr": "storj_sat_audit{type=\"score\",instance=~\"$node.*\"} * 100",
+          "expr": "storj_sat_audit{type=~\"score|auditScore\",instance=~\"$node.*\"} * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2038,7 +2038,7 @@
       "repeatDirection": "v",
       "targets": [
         {
-          "expr": "storj_sat_summary{type=\"onlineScore\",instance=~\"$node.*\"} * 100",
+          "expr": "(storj_sat_summary{type=\"onlineScore\",instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"}) * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/alternatives/Storj-Exporter-dashboard.json
+++ b/alternatives/Storj-Exporter-dashboard.json
@@ -755,7 +755,7 @@
       "pluginVersion": "6.3.3",
       "targets": [
         {
-          "expr": "avg(storj_sat_audit{type=\"score\"}) by(instance) * 100",
+          "expr": "avg(storj_sat_audit{type=~\"score|auditScore\"}) by(instance) * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1596,7 +1596,7 @@
       "repeatDirection": "v",
       "targets": [
         {
-          "expr": "storj_sat_audit{type=\"score\",instance=~\"$node.*\"} * 100",
+          "expr": "storj_sat_audit{type=~\"score|auditScore\",instance=~\"$node.*\"} * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/alternatives/dashboard_exporter_combined.json
+++ b/alternatives/dashboard_exporter_combined.json
@@ -1131,7 +1131,7 @@
       "pluginVersion": "7.3.6",
       "targets": [
         {
-          "expr": "min(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"})",
+          "expr": "min(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"})",
           "interval": "",
           "legendFormat": "Min Uptime",
           "refId": "A"
@@ -1190,7 +1190,7 @@
       "pluginVersion": "7.3.6",
       "targets": [
         {
-          "expr": "min(storj_sat_audit{type=\"score\", instance=~\"$node.*\"})",
+          "expr": "min(storj_sat_audit{type=~\"score|auditScore\", instance=~\"$node.*\"})",
           "interval": "",
           "legendFormat": "Min Audit",
           "refId": "A"
@@ -2276,14 +2276,14 @@
               "refId": "J"
             },
             {
-              "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"}) by(instance) * 100",
+              "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"}) by(instance) * 100",
               "hide": false,
               "interval": "",
               "legendFormat": "{{instance}} | Uptime",
               "refId": "C"
             },
             {
-              "expr": "avg(storj_sat_audit{type=\"score\", instance=~\"$node.*\"}) by(instance) * 100",
+              "expr": "avg(storj_sat_audit{type=~\"score|auditScore\", instance=~\"$node.*\"}) by(instance) * 100",
               "hide": false,
               "interval": "",
               "legendFormat": "{{instance}} | Audit",
@@ -5342,14 +5342,14 @@
               "refId": "E"
             },
             {
-              "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"}) by(url) * 100",
+              "expr": "avg(storj_sat_summary{type=\"onlineScore\", instance=~\"$node.*\"} or storj_sat_audit{type=\"onlineScore\", instance=~\"$node.*\"}) by(url) * 100",
               "hide": false,
               "interval": "",
               "legendFormat": "{{url}} | Uptime",
               "refId": "C"
             },
             {
-              "expr": "avg(storj_sat_audit{type=\"score\",instance=~\"$node.*\"}) by(url) * 100",
+              "expr": "avg(storj_sat_audit{type=~\"score|auditScore\",instance=~\"$node.*\"}) by(url) * 100",
               "hide": false,
               "legendFormat": "{{url}} | Audit",
               "refId": "D"


### PR DESCRIPTION
* storj_sat_audit type="score" renamed to "auditScore" - use pattern to match either.
* storj_sat_summary type="onlineScore" moved to storj_sat_audit type="onlineScore" - use 'or' to use whatever exists.
* storj_sat_audit type="successCount" no longer exists - colapses nicely on some dashboards - left in case re-added to API.
* storj_sat_uptime is removed - only used in alternatives/Storj-Exporter-dashboard.json - no idea so left code alone.