### PR TITLE
get instance of storj nodes only

### DIFF
--- a/Storj-Exporter-Boom-Table.json
+++ b/Storj-Exporter-Boom-Table.json
@@ -2495,11 +2495,11 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(instance)",
+          "query": "storj_node_info",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
-        "regex": "",
+        "regex": "/instance=\"(?<text>[^\"]+)|chip=\"(?<value>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
The current query returns `instance` values for various metrics not only the ones exposed by the `storj-exporter`. This change fixes that by polling only the `storj_node_info` metric.